### PR TITLE
Add User Agent Blacklist file

### DIFF
--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -2,3 +2,4 @@ FROM nginx:stable-alpine
 COPY misp.conf /etc/nginx/conf.d/misp.conf
 RUN rm /etc/nginx/conf.d/default.conf
 COPY nginx.conf /etc/nginx/nginx.conf
+COPY blockuseragents.rules /etc/nginx/blockuseragents.rules


### PR DESCRIPTION
The user should create a file named blockuseragents.rules and add these lines:
map $http_user_agent $blockedagent {
        default         0;
        ~*malicious     1;
        ~*bot           1;
        ~*backdoor      1;
        ~*crawler       1;
        ~*bandit        1;
}